### PR TITLE
VSCode の Devcontainers上でビルドできるようにする

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/qmk/qmk_cli:latest
+
+# Update packages
+# RUN apt-get update && apt upgrade -y
+
+# Setup qmk_firmware
+ARG QMK_TAG
+ARG QMK_PATH
+RUN git clone https://github.com/qmk/qmk_firmware.git -b ${QMK_TAG} ${QMK_PATH} \
+    && qmk setup --home ${QMK_PATH} --yes
+
+# Install python modules
+RUN /usr/bin/python3 -m pip install -r ${QMK_PATH}/requirements.txt
+
+# Remove other keyboards
+RUN rm -rf /${QMK_PATH}/keyboards/*
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+  "name": "build_keyball",
+  
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "QMK_TAG": "0.22.14",
+      "QMK_PATH": "__qmk__"
+    }
+  },
+
+  "workspaceFolder": "/__qmk__/keyboards",
+  "workspaceMount": "source=${localWorkspaceFolder}/qmk_firmware/keyboards/keyball,target=/__qmk__/keyboards/keyball,type=bind,consistency=cached",
+  "mounts": [
+    "source=${localWorkspaceFolder}/qmk_firmware/.build,target=/__qmk__/keyboards/release,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/bin/devcontainer/qmkb.sh,target=/usr/local/bin/qmkb,type=bind,consistency=cached"
+  ],
+
+  "remoteEnv": {
+    "WORKSPACE_FOLDER": "${containerWorkspaceFolder}",
+    "BUILD_DEF_KB": "keyball/keyball39",
+    "BUILD_DEF_KM": "default"
+  },
+}

--- a/bin/devcontainer/qmkb.sh
+++ b/bin/devcontainer/qmkb.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Set default build target 
+build_kb="${BUILD_DEF_KB}"
+build_km="${BUILD_DEF_KM}"
+
+while getopts "b:m:" opt; do
+  case $opt in
+    b) build_kb=$OPTARG;;
+    m) build_km=$OPTARG;;
+    
+    \?) exit 1;;
+    :) exit 1;;
+  esac
+done
+
+# Get build target from current path, if matched.
+pattern="^${WORKSPACE_FOLDER}(/([^/]+/[^/]+))?(/keymaps/([^/]+))?"
+if [[ $(pwd) =~ ${pattern} ]]; then
+  if [[ ${BASH_REMATCH[2]} ]]; then
+    build_kb=${BASH_REMATCH[2]}
+  fi
+  if [[ ${BASH_REMATCH[4]} ]]; then
+    build_km=${BASH_REMATCH[4]}
+  fi
+fi
+
+# Execute Build & Copy
+echo "Build target: keyboard=${build_kb} / keymap=${build_km}"
+read -p "Do you want to proceed? (Y/n): " response
+response=${response:-Y}
+if [[ "${response}" =~ ^[Yy]$ ]]; then
+  qmk compile -j 4 -kb ${build_kb} -km ${build_km}
+  if [[ $? -eq 0 ]]; then
+    cp "${WORKSPACE_FOLDER}/../.build/${build_kb//\//_}_${build_km}.hex" "${WORKSPACE_FOLDER}/release/"
+  fi
+fi


### PR DESCRIPTION
VisualStudio Code の 開発コンテナ機能を使用して、Docker上にビルド環境をワンタッチで構築します。
また、簡単にビルドするためのコマンド「qmkb」を追加しています。

## 前提
VSCodeのDevContainersとDockerが利用できる環境が必要です。

## qmkb コマンド

### 概要
qmkのコンパイルを簡単に扱うためのエイリアスコマンドです。
コンパイルに成功すると、`qmk_firmware/.build/` に hexファイルをコピーします。

実行には`Ctrl` + `@` で表示されるターミナル上で `qmkb` と入力してください。


### 実行方法

ビルド対象のキーボード、キーマップはコマンド実行時のパスから取得しますが、
オプションにて明示的に指定することも可能です。

```
qmkb [-b (ビルド対象のキーボード)] [-m (ビルド対象のキーマップ)]
```

オプション指定がなく、パスからも取得できない場合は環境変数から取得します。
デフォルトの値を変更したい場合は、`devcontainer.json` の `BUILD_DEF_KB` `BUILD_DEF_KM` の値を変更してください。
